### PR TITLE
Add network permission

### DIFF
--- a/org.twinery.Twine.yaml
+++ b/org.twinery.Twine.yaml
@@ -15,6 +15,8 @@ finish-args:
   # At least that's what the legends tell. it might be worth experimenting
   # with dropping this permission.
   - --share=ipc
+  # Required to download remote story formats.
+  - --share=network
   # Required to improve Electron performance with hardware accrelation
   - --device=dri
   # Allows to send and receive files in the Downloads directory


### PR DESCRIPTION
This is required for remote story format imports to work.

This will likely fix https://github.com/flathub/org.twinery.Twine/issues/1, though I do not know how to test this.